### PR TITLE
include symlinks for Zero2: `brcm` `fmac43455-sdio` firmware

### DIFF
--- a/brcm/brcmfmac43455-sdio.radxa,zero2.bin
+++ b/brcm/brcmfmac43455-sdio.radxa,zero2.bin
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.bin

--- a/brcm/brcmfmac43455-sdio.radxa,zero2.txt
+++ b/brcm/brcmfmac43455-sdio.radxa,zero2.txt
@@ -1,0 +1,1 @@
+brcmfmac43455-sdio.txt


### PR DESCRIPTION
#### include symlinks for Zero2: `brcm` `fmac43455-sdio` firmware

- it works without them, but lets remove errors ref firmware from dmesg

This complements #40 
