### PR TITLE
Include symlinks for RockPi 4b: brcm fmac43456-sdio firmware.

### DIFF
--- a/brcm/brcmfmac43456-sdio.radxa,rockpi4b.bin
+++ b/brcm/brcmfmac43456-sdio.radxa,rockpi4b.bin
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.bin

--- a/brcm/brcmfmac43456-sdio.radxa,rockpi4b.txt
+++ b/brcm/brcmfmac43456-sdio.radxa,rockpi4b.txt
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.txt


### PR DESCRIPTION
```
Linux rockpi-4b 5.15.80-rockchip64 #22.11.1 SMP PREEMPT Wed Nov 30 11:12:47 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
```
Fixed issue with loading firmware
```
Dec 03 19:06:12 rockpi-4b kernel: brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43456-sdio for chip BCM4345/9
Dec 03 19:06:12 rockpi-4b kernel: brcmfmac mmc2:0001:1: Direct firmware load for brcm/brcmfmac43456-sdio.radxa,rockpi4b.bin failed with error -2
Dec 03 19:06:12 rockpi-4b kernel: brcmfmac mmc2:0001:1: Direct firmware load for brcm/brcmfmac43456-sdio.radxa,rockpi4b.txt failed with error -2
```
