### PR TITLE
add symlink to nvram_AP6275P.txt for rockchip 6.1 bsp

### DIFF
--- a/ap6275p/nvram_ap6275p.txt
+++ b/ap6275p/nvram_ap6275p.txt
@@ -1,0 +1,1 @@
+nvram_AP6275P.txt


### PR DESCRIPTION
For the new Rockchip 6.1 BSP introduced in, https://github.com/armbian/build/pull/6356, a symlink is required for AP6275P to operate properly.  The kernel will look for the module name, on 5.10 the name is "AP6275P" and on 6.1 it's "ap6275p".